### PR TITLE
Clickoutside: add event to callback

### DIFF
--- a/src/utils/clickoutside.js
+++ b/src/utils/clickoutside.js
@@ -29,9 +29,9 @@ function createDocumentHandler(el, binding, vnode) {
     if (binding.expression &&
       el[ctx].methodName &&
       vnode.context[el[ctx].methodName]) {
-      vnode.context[el[ctx].methodName]();
+      vnode.context[el[ctx].methodName](mousedown);
     } else {
-      el[ctx].bindingFn && el[ctx].bindingFn();
+      el[ctx].bindingFn && el[ctx].bindingFn(mousedown);
     }
   };
 }


### PR DESCRIPTION
Adding `mousedown` event as argument to directive `v-clickoutside` callback
